### PR TITLE
Normalize the return to an array instead of arguments object

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -13,6 +13,8 @@ exports.argumentsOf = argsOf;
 
 // Sanitize arguments
 function sanitize(args, caller, order) {
+        args = Array.prototype.slice.call(args);
+        
 	if(typeOf(caller) == "Array") {
 		order = caller;
 		caller = null;
@@ -21,7 +23,7 @@ function sanitize(args, caller, order) {
 			, sanitized = {};
 	}
 	
-	Array.prototype.slice.call(args).forEach(function(arg, oldIndex) {
+	args.forEach(function(arg, oldIndex) {
 		order.some(function(type, newIndex) {
 			if(typeOf(type) == "Function" && typeOf(arg) == nameOf(type)) {
 				args[newIndex] = arg;


### PR DESCRIPTION
Might be a matter of preference but I prefer to have an array returned when not providing a function instead of the arguments object.
