### PR TITLE
Allow for default values

### DIFF
--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -23,7 +23,9 @@ function sanitize(args, caller, order) {
 	
 	Array.prototype.slice.call(args).forEach(function(arg, oldIndex) {
 		order.some(function(type, newIndex) {
-			if(typeOf(type) == "Function" && typeOf(arg) == nameOf(type)) {
+                        var _type = typeOf(type) == "Object" ? type.type : type;
+                        
+			if(typeOf(_type) == "Function" && typeOf(arg) == nameOf(_type)) {
 				args[newIndex] = arg;
 				if(caller) sanitized[argNames[newIndex]] = arg;
 				delete order[newIndex];
@@ -31,6 +33,15 @@ function sanitize(args, caller, order) {
 			}
 		});
 	});
+        
+        if (order.length) {
+            order.forEach(function(type, newIndex) {
+                if (typeOf(type) == "Object" && type["default"]) {
+                    args[newIndex] = type["default"];
+                    if(caller) sanitized[argNames[newIndex]] = type["default"];
+                }
+            })
+        }
 	
 	return caller ? sanitized : args;
 }


### PR DESCRIPTION
This will allow for default argument values

example:

``` js
function F(path, options, cb) {
    sanitize(arguments, F, [String, Object, {type: Function, default: function() {}}]);
}
```
