### PR TITLE
Fixes typeOf to support custom object

### DIFF
--- a/lib/typechecks.js
+++ b/lib/typechecks.js
@@ -7,7 +7,7 @@ exports.argsOf = argumentsOf;
 
 // Return the type of an object aka safe typeof
 function typeOf(o) {
-	return Object.prototype.toString.call(o).match(/(\w+)\]/)[1];
+	return o && o.constructor ? o.constructor.name : Object.prototype.toString.call(o).match(/(\w+)\]/)[1];
 }
 
 // Return the name of a function aka class name

--- a/test/typechecks.js
+++ b/test/typechecks.js
@@ -52,6 +52,17 @@ describe("typeOf(obj)", function() {
 		it("should return 'Object' when obj is an Object", function() {
 			typeOf({}).should.eql("Object");
 		});
+                
+	});
+        
+        describe("Custom Objects", function() {
+		it("should return 'ClassName' when obj is an instance of function ClassName", function() {
+                    function ClassName() {};
+                    
+                    var foo = new ClassName();                                        
+                    
+		    typeOf(foo).should.eql("ClassName");
+		});
 	});
 	
 	describe("Array", function() {


### PR DESCRIPTION
Fixes typeOf to support custom objects so `typeOf(new Server()) == 'Server'`
also makes adding Server as a param work to classify it.
